### PR TITLE
Xcodebuild append fix

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -61,7 +61,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a4aca0221c17db274953d8114b4bb872c580bca150e05eefd85570a1300fc682"
+  digest = "1:8a22d205108031885307c95b0dc86a249dab77b9ca676ef02500f3f6c430ae02"
   name = "github.com/bitrise-tools/xcode-project"
   packages = [
     "serialized",
@@ -71,7 +71,7 @@
     "xcworkspace",
   ]
   pruneopts = "UT"
-  revision = "906954f33da7e58b9522b0de8b1937ee5b1fdfc5"
+  revision = "f0b50430d7de5f6ef38415a65cf132767ca5d22c"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -43,7 +43,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c5cc2e4b8bbf7c9b5ba190215024766652ce1ab63e1fb1f500f5229108de2fe1"
+  digest = "1:804d88125f6465d91c6c28bc73c5509060c3e38d8c0a5156b35199bdf87d0059"
   name = "github.com/bitrise-tools/go-xcode"
   packages = [
     "certificateutil",
@@ -57,7 +57,7 @@
     "xcpretty",
   ]
   pruneopts = "UT"
-  revision = "07db8cf760f5213241e12c0595158aedce96669a"
+  revision = "9e1bce1ce3369fe30c806e54836ccb2cc7a697aa"
 
 [[projects]]
   branch = "master"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -98,8 +98,8 @@ workflows:
     - SIMULATOR_OS_VERSION: "11.4"
     - OUTPUT_TOOL: xcodebuild
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
-    - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_SOURCE_DIR/ddata/sample-apps-ios-workspace-swift.app"
-    - BITRISE_APP_DIR_PATH_LIST_EXPECTED: "$BITRISE_SOURCE_DIR/ddata/sample-apps-ios-workspace-swift.app|$BITRISE_SOURCE_DIR/ddata/bitfall.sample-apps-ios-workspace-swift-watch.app"
+    - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app"
+    - BITRISE_APP_DIR_PATH_LIST_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app|$BITRISE_DEPLOY_DIR/bitfall.sample-apps-ios-workspace-swift-watch.app"
     after_run:
     - _common
     - test_multi_target_workspace
@@ -170,22 +170,22 @@ workflows:
             #!/bin/bash
             set -e
 
-            if [ -z ${BITRISE_APP_DIR_PATH_EXPECTED} ] ; then
+            if [[ -z "$BITRISE_APP_DIR_PATH_EXPECTED" ]] ; then
               echo BITRISE_APP_DIR_PATH_EXPECTED is empty  
             else 
-              if [ -z ${BITRISE_APP_DIR_PATH+x} ] || [ ${BITRISE_APP_DIR_PATH+x} != ${BITRISE_APP_DIR_PATH_EXPECTED+x} ] ; then
-                echo "[!] Missing Exported Artifact: should have: $BITRISE_APP_DIR_PATH_EXPECTED and have: $BITRISE_APP_DIR_PATH"
+              if [[ -z "$BITRISE_APP_DIR_PATH" ]] || [[ "$BITRISE_APP_DIR_PATH" != "$BITRISE_APP_DIR_PATH_EXPECTED" ]] ; then
+                echo "[!] Missing Exported BITRISE_APP_DIR_PATH: should have: $BITRISE_APP_DIR_PATH_EXPECTED and have: $BITRISE_APP_DIR_PATH"
                 exit 1
               else
                 echo "BITRISE_APP_DIR_PATH -> $BITRISE_APP_DIR_PATH"
               fi
             fi
 
-            if [ -z ${BITRISE_APP_DIR_PATH_LIST_EXPECTED} ] ; then
+            if [[ -z "$BITRISE_APP_DIR_PATH_LIST_EXPECTED" ]] ; then
               echo BITRISE_APP_DIR_PATH_LIST_EXPECTED is empty  
             else 
-              if [ -z ${BITRISE_APP_DIR_PATH_LIST+x} ] || [ ${BITRISE_APP_DIR_PATH_LIST+x} != ${BITRISE_APP_DIR_PATH_LIST_EXPECTED+x} ] ; then
-                echo "[!] Missing Exported Artifact: should have: $BITRISE_APP_DIR_PATH_LIST_EXPECTED and have: $BITRISE_APP_DIR_PATH_LIST"
+              if [[ -z "$BITRISE_APP_DIR_PATH_LIST" ]] || [[ "$BITRISE_APP_DIR_PATH_LIST" != "$BITRISE_APP_DIR_PATH_LIST_EXPECTED" ]] ; then
+                echo "[!] Missing Exported BITRISE_APP_DIR_PATH_LIST: should have: $BITRISE_APP_DIR_PATH_LIST_EXPECTED and have: $BITRISE_APP_DIR_PATH_LIST"
                 exit 1
               else
                 echo "BITRISE_APP_DIR_PATH_LIST -> $BITRISE_APP_DIR_PATH_LIST"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -170,26 +170,18 @@ workflows:
             #!/bin/bash
             set -e
 
-            if [[ -z "$BITRISE_APP_DIR_PATH_EXPECTED" ]] ; then
-              echo BITRISE_APP_DIR_PATH_EXPECTED is empty  
-            else 
-              if [[ -z "$BITRISE_APP_DIR_PATH" ]] || [[ "$BITRISE_APP_DIR_PATH" != "$BITRISE_APP_DIR_PATH_EXPECTED" ]] ; then
-                echo "[!] Missing Exported BITRISE_APP_DIR_PATH: should have: $BITRISE_APP_DIR_PATH_EXPECTED and have: $BITRISE_APP_DIR_PATH"
-                exit 1
-              else
-                echo "BITRISE_APP_DIR_PATH -> $BITRISE_APP_DIR_PATH"
-              fi
+            if [[ "$BITRISE_APP_DIR_PATH_EXPECTED" != "$BITRISE_APP_DIR_PATH" ]] ; then 
+              echo "BITRISE_APP_DIR_PATH (\"$BITRISE_APP_DIR_PATH\") should be: \"$BITRISE_APP_DIR_PATH_EXPECTED\""
+              exit 1
+            else
+              echo "BITRISE_APP_DIR_PATH: $BITRISE_APP_DIR_PATH"
             fi
 
-            if [[ -z "$BITRISE_APP_DIR_PATH_LIST_EXPECTED" ]] ; then
-              echo BITRISE_APP_DIR_PATH_LIST_EXPECTED is empty  
-            else 
-              if [[ -z "$BITRISE_APP_DIR_PATH_LIST" ]] || [[ "$BITRISE_APP_DIR_PATH_LIST" != "$BITRISE_APP_DIR_PATH_LIST_EXPECTED" ]] ; then
-                echo "[!] Missing Exported BITRISE_APP_DIR_PATH_LIST: should have: $BITRISE_APP_DIR_PATH_LIST_EXPECTED and have: $BITRISE_APP_DIR_PATH_LIST"
-                exit 1
-              else
-                echo "BITRISE_APP_DIR_PATH_LIST -> $BITRISE_APP_DIR_PATH_LIST"
-              fi
+            if [[ "$BITRISE_APP_DIR_PATH_LIST_EXPECTED" != "$BITRISE_APP_DIR_PATH_LIST" ]] ; then 
+              echo "BITRISE_APP_DIR_PATH_LIST (\"$BITRISE_APP_DIR_PATH_LIST\") should be: \"$BITRISE_APP_DIR_PATH_LIST_EXPECTED\""
+              exit 1
+            else
+              echo "BITRISE_APP_DIR_PATH_LIST: $BITRISE_APP_DIR_PATH_LIST"
             fi
 
   # ----------------------------------------------------------------

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -96,10 +96,10 @@ workflows:
     - BITRISE_PROJECT_PATH: sample-apps-ios-workspace-swift.xcworkspace
     - BITRISE_SCHEME: sample-apps-ios-workspace-swift
     - SIMULATOR_OS_VERSION: "11.4"
-    - OUTPUT_TOOL: xcpretty
+    - OUTPUT_TOOL: xcodebuild
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED: ""
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED: ""
+    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED: "$BITRISE_SOURCE_DIR/ddata/sample-apps-ios-workspace-swift.app"
+    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED: "$BITRISE_SOURCE_DIR/ddata/sample-apps-ios-workspace-swift.app|$BITRISE_SOURCE_DIR/ddata/bitfall.sample-apps-ios-workspace-swift-watch.app"
     after_run:
     - _common
     - test_multi_target_workspace
@@ -220,43 +220,3 @@ workflows:
             #!/bin/bash
             set -ex
             stepman audit --step-yml ./step.yml
-
-  share-this-step:
-    envs:
-      # if you want to share this step into a StepLib
-      - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
-      - BITRISE_STEP_ID: $BITRISE_STEP_ID
-      - BITRISE_STEP_VERSION: $BITRISE_STEP_VERSION
-      - BITRISE_STEP_GIT_CLONE_URL: $BITRISE_STEP_GIT_CLONE_URL
-    description: |-
-      If this is the first time you try to share a Step you should
-      first call: $ bitrise share
-
-      This will print you a guide, and information about how Step sharing
-      works. Please read it at least once!
-
-      As noted in the Step sharing guide you'll have to fork the
-      StepLib you want to share this step into. Once you're done with forking
-      the repository you should set your own fork's git clone URL
-      in the `.bitrise.secrets.yml` file, or here in the `envs` section,
-      as the value of the `MY_STEPLIB_REPO_FORK_GIT_URL` environment.
-
-      You're now ready to share this Step, just make sure that
-      the `BITRISE_STEP_ID` and `BITRISE_STEP_VERSION`
-      environments are set to the desired values!
-
-      To share this Step into a StepLib you can just run: $ bitrise run share-this-step
-
-      Once it finishes the only thing left is to actually create a Pull Request,
-      the way described in the guide printed at the end of the process.
-    before_run:
-    - audit-this-step
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            bitrise share start -c "${MY_STEPLIB_REPO_FORK_GIT_URL}"
-            bitrise share create --stepid "${BITRISE_STEP_ID}" --tag "${BITRISE_STEP_VERSION}" --git "${BITRISE_STEP_GIT_CLONE_URL}"
-            bitrise share finish

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,8 +21,8 @@ workflows:
     - OUTPUT_TOOL: xcodebuild
     - SIMULATOR_OS_VERSION: "latest"
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED: $BITRISE_DEPLOY_DIR/ios-simple-objc.app
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED: $BITRISE_DEPLOY_DIR/ios-simple-objc.app
+    - BITRISE_APP_DIR_PATH_EXPECTED: $BITRISE_DEPLOY_DIR/ios-simple-objc.app
+    - BITRISE_APP_DIR_PATH_LIST_EXPECTED: $BITRISE_DEPLOY_DIR/ios-simple-objc.app
     after_run:
     - _common
 
@@ -47,8 +47,8 @@ workflows:
     - OUTPUT_TOOL: xcpretty
     - SIMULATOR_OS_VERSION: latest
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED: $BITRISE_DEPLOY_DIR/ios-xcode-8.0.app
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED: $BITRISE_DEPLOY_DIR/ios-xcode-8.0.app
+    - BITRISE_APP_DIR_PATH_EXPECTED: $BITRISE_DEPLOY_DIR/ios-xcode-8.0.app
+    - BITRISE_APP_DIR_PATH_LIST_EXPECTED: $BITRISE_DEPLOY_DIR/ios-xcode-8.0.app
     before_run:
     - test_objc
     after_run:
@@ -66,8 +66,8 @@ workflows:
     - SIMULATOR_OS_VERSION: "latest"
     - OUTPUT_TOOL: xcpretty
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/code-sign-test.app"
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED: "$BITRISE_DEPLOY_DIR/code-sign-test.app|$BITRISE_DEPLOY_DIR/watchkit-app.app"
+    - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/code-sign-test.app"
+    - BITRISE_APP_DIR_PATH_LIST_EXPECTED: "$BITRISE_DEPLOY_DIR/code-sign-test.app|$BITRISE_DEPLOY_DIR/watchkit-app.app"
     after_run:
     - _common
 
@@ -83,8 +83,8 @@ workflows:
     - SIMULATOR_OS_VERSION: "latest"
     - OUTPUT_TOOL: xcpretty
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app"
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app"
+    - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app"
+    - BITRISE_APP_DIR_PATH_LIST_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app"
     after_run:
     - _common
 
@@ -98,8 +98,8 @@ workflows:
     - SIMULATOR_OS_VERSION: "11.4"
     - OUTPUT_TOOL: xcodebuild
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED: "$BITRISE_SOURCE_DIR/ddata/sample-apps-ios-workspace-swift.app"
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED: "$BITRISE_SOURCE_DIR/ddata/sample-apps-ios-workspace-swift.app|$BITRISE_SOURCE_DIR/ddata/bitfall.sample-apps-ios-workspace-swift-watch.app"
+    - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_SOURCE_DIR/ddata/sample-apps-ios-workspace-swift.app"
+    - BITRISE_APP_DIR_PATH_LIST_EXPECTED: "$BITRISE_SOURCE_DIR/ddata/sample-apps-ios-workspace-swift.app|$BITRISE_SOURCE_DIR/ddata/bitfall.sample-apps-ios-workspace-swift-watch.app"
     after_run:
     - _common
     - test_multi_target_workspace
@@ -116,8 +116,8 @@ workflows:
     - SIMULATOR_OS_VERSION: "11.4"
     - OUTPUT_TOOL: xcpretty
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app"
-    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app|$BITRISE_DEPLOY_DIR/bitfall.sample-apps-ios-workspace-swift-watch.app"
+    - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app"
+    - BITRISE_APP_DIR_PATH_LIST_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app|$BITRISE_DEPLOY_DIR/bitfall.sample-apps-ios-workspace-swift-watch.app"
     after_run:
     - _common
 
@@ -170,22 +170,22 @@ workflows:
             #!/bin/bash
             set -e
 
-            if [ -z ${BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED} ] ; then
-              echo BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED is empty  
+            if [ -z ${BITRISE_APP_DIR_PATH_EXPECTED} ] ; then
+              echo BITRISE_APP_DIR_PATH_EXPECTED is empty  
             else 
-              if [ -z ${BITRISE_APP_DIR_PATH+x} ] || [ ${BITRISE_APP_DIR_PATH+x} != ${BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED+x} ] ; then
-                echo "[!] Missing Exported Artifact: should have: $BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED and have: $BITRISE_APP_DIR_PATH"
+              if [ -z ${BITRISE_APP_DIR_PATH+x} ] || [ ${BITRISE_APP_DIR_PATH+x} != ${BITRISE_APP_DIR_PATH_EXPECTED+x} ] ; then
+                echo "[!] Missing Exported Artifact: should have: $BITRISE_APP_DIR_PATH_EXPECTED and have: $BITRISE_APP_DIR_PATH"
                 exit 1
               else
                 echo "BITRISE_APP_DIR_PATH -> $BITRISE_APP_DIR_PATH"
               fi
             fi
 
-            if [ -z ${BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED} ] ; then
-              echo BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED is empty  
+            if [ -z ${BITRISE_APP_DIR_PATH_LIST_EXPECTED} ] ; then
+              echo BITRISE_APP_DIR_PATH_LIST_EXPECTED is empty  
             else 
-              if [ -z ${BITRISE_APP_DIR_PATH_LIST+x} ] || [ ${BITRISE_APP_DIR_PATH_LIST+x} != ${BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED+x} ] ; then
-                echo "[!] Missing Exported Artifact: should have: $BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED and have: $BITRISE_APP_DIR_PATH_LIST"
+              if [ -z ${BITRISE_APP_DIR_PATH_LIST+x} ] || [ ${BITRISE_APP_DIR_PATH_LIST+x} != ${BITRISE_APP_DIR_PATH_LIST_EXPECTED+x} ] ; then
+                echo "[!] Missing Exported Artifact: should have: $BITRISE_APP_DIR_PATH_LIST_EXPECTED and have: $BITRISE_APP_DIR_PATH_LIST"
                 exit 1
               else
                 echo "BITRISE_APP_DIR_PATH_LIST -> $BITRISE_APP_DIR_PATH_LIST"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -13,6 +13,7 @@ app:
 workflows:
   test_objc:
     envs:
+    - XCODEBUILD_OPTIONS:
     - SAMPLE_APP_URL: https://github.com/bitrise-io/sample-apps-ios-simple-objc.git
     - BRANCH: master
     - BITRISE_PROJECT_PATH: ios-simple-objc/ios-simple-objc.xcodeproj
@@ -38,6 +39,7 @@ workflows:
     - errcheck:
     - go-test:
     envs:
+    - XCODEBUILD_OPTIONS:
     - SAMPLE_APP_URL: https://github.com/bitrise-samples/ios-xcode-8.0.git
     - COMMIT: "52ca16a9cead25be8c95c54e7fd53ce8fd945330"
     - BITRISE_PROJECT_PATH: ios-xcode-8.0/ios-xcode-8.0.xcodeproj
@@ -56,6 +58,7 @@ workflows:
     before_run:
     # - test_xcode_8
     envs:
+    - XCODEBUILD_OPTIONS:
     - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-multi-target.git
     - COMMIT: "ab36ed563bbc3125118e9f27df91474822dc0d46"
     - BITRISE_PROJECT_PATH: code-sign-test.xcodeproj
@@ -72,6 +75,7 @@ workflows:
     before_run:
     - test_multi_target
     envs:
+    - XCODEBUILD_OPTIONS:
     - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
     - BRANCH: master
     - BITRISE_PROJECT_PATH: sample-apps-ios-workspace-swift.xcworkspace
@@ -84,10 +88,27 @@ workflows:
     after_run:
     - _common
 
+  test_multi_target_workspace_custom_derived_data_path:
+    envs:
+    - XCODEBUILD_OPTIONS: "-derivedDataPath ./ddata"
+    - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
+    - BRANCH: watch
+    - BITRISE_PROJECT_PATH: sample-apps-ios-workspace-swift.xcworkspace
+    - BITRISE_SCHEME: sample-apps-ios-workspace-swift
+    - SIMULATOR_OS_VERSION: "11.4"
+    - OUTPUT_TOOL: xcpretty
+    - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
+    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED: ""
+    - BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED: ""
+    after_run:
+    - _common
+    - test_multi_target_workspace
+
   test_multi_target_workspace:
     before_run:
     - test_workspace
     envs:
+    - XCODEBUILD_OPTIONS:
     - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
     - BRANCH: watch
     - BITRISE_PROJECT_PATH: sample-apps-ios-workspace-swift.xcworkspace
@@ -149,18 +170,26 @@ workflows:
             #!/bin/bash
             set -e
 
-            if [ $BITRISE_APP_DIR_PATH != $BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED ] ; then
-              echo "[!] Missing Exported Artifact: should have:\n$BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED and have\n$BITRISE_APP_DIR_PATH"
-              exit 1
-            else
-              echo "BITRISE_APP_DIR_PATH -> $BITRISE_APP_DIR_PATH"
+            if [ -z ${BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED} ] ; then
+              echo BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED is empty  
+            else 
+              if [ -z ${BITRISE_APP_DIR_PATH+x} ] || [ ${BITRISE_APP_DIR_PATH+x} != ${BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED+x} ] ; then
+                echo "[!] Missing Exported Artifact: should have: $BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_EXPECTED and have: $BITRISE_APP_DIR_PATH"
+                exit 1
+              else
+                echo "BITRISE_APP_DIR_PATH -> $BITRISE_APP_DIR_PATH"
+              fi
             fi
 
-            if [ $BITRISE_APP_DIR_PATH_LIST != $BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED ] ; then
-              echo "[!] Missing Exported Artifact: should have:\n$BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED and have\n$BITRISE_APP_DIR_PATH_LIST"
-              exit 1
-            else
-              echo "BITRISE_APP_DIR_PATH_LIST -> $BITRISE_APP_DIR_PATH_LIST"
+            if [ -z ${BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED} ] ; then
+              echo BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED is empty  
+            else 
+              if [ -z ${BITRISE_APP_DIR_PATH_LIST+x} ] || [ ${BITRISE_APP_DIR_PATH_LIST+x} != ${BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED+x} ] ; then
+                echo "[!] Missing Exported Artifact: should have: $BITRISE_EXPORTED_SIMULATOR_BUILDS_PATH_MAP_EXPECTED and have: $BITRISE_APP_DIR_PATH_LIST"
+                exit 1
+              else
+                echo "BITRISE_APP_DIR_PATH_LIST -> $BITRISE_APP_DIR_PATH_LIST"
+              fi
             fi
 
   # ----------------------------------------------------------------

--- a/main.go
+++ b/main.go
@@ -251,11 +251,9 @@ func main() {
 			failf("Failed to open xcproj - (%s), error:", cfg.ProjectPath, err)
 		}
 
-		var customOptions []string
-		for _, customOption := range strings.Split(cfg.XcodebuildOptions, " ") {
-			if customOption != "" {
-				customOptions = append(customOptions, customOption)
-			}
+		customOptions, err := shellquote.Split(cfg.XcodebuildOptions)
+		if err != nil {
+			failf("Failed to shell split XcodebuildOptions (%s), error: %s", cfg.XcodebuildOptions)
 		}
 
 		// Get the simulator name

--- a/main.go
+++ b/main.go
@@ -272,9 +272,11 @@ func main() {
 			failf("Failed to get scheme (%s) build target dir, error: %s", err)
 		}
 
+		log.Debugf("Scheme build dir: %s", schemeBuildDir)
+
 		// Export the artifact from the build dir to the output_dir
 		if exportedArtifacts, err = exportArtifacts(proj, cfg.Scheme, schemeBuildDir, cfg.Configuration, cfg.SimulatorPlatform, absOutputDir); err != nil {
-			log.Warnf("Failed to export the artifacts, error: %s", err)
+			failf("Failed to export the artifacts, error: %s", err)
 		}
 	}
 

--- a/vendor/github.com/bitrise-tools/go-xcode/xcodebuild/build.go
+++ b/vendor/github.com/bitrise-tools/go-xcode/xcodebuild/build.go
@@ -45,6 +45,7 @@ type CommandBuilder struct {
 	isWorkspace   bool
 	scheme        string
 	configuration string
+	destination   string
 
 	// buildsetting
 	forceDevelopmentTeam              string
@@ -77,6 +78,12 @@ func NewCommandBuilder(projectPath string, isWorkspace bool, action Action) *Com
 // SetScheme ...
 func (c *CommandBuilder) SetScheme(scheme string) *CommandBuilder {
 	c.scheme = scheme
+	return c
+}
+
+// SetDestination ...
+func (c *CommandBuilder) SetDestination(destination string) *CommandBuilder {
+	c.destination = destination
 	return c
 }
 
@@ -154,24 +161,39 @@ func (c *CommandBuilder) cmdSlice() []string {
 	if c.scheme != "" {
 		slice = append(slice, "-scheme", c.scheme)
 	}
+
 	if c.configuration != "" {
 		slice = append(slice, "-configuration", c.configuration)
 	}
 
-	if c.forceDevelopmentTeam != "" {
-		slice = append(slice, fmt.Sprintf("DEVELOPMENT_TEAM=%s", c.forceDevelopmentTeam))
-	}
-	if c.forceProvisioningProfileSpecifier != "" {
-		slice = append(slice, fmt.Sprintf("PROVISIONING_PROFILE_SPECIFIER=%s", c.forceProvisioningProfileSpecifier))
-	}
-	if c.forceProvisioningProfile != "" {
-		slice = append(slice, fmt.Sprintf("PROVISIONING_PROFILE=%s", c.forceProvisioningProfile))
-	}
-	if c.forceCodeSignIdentity != "" {
-		slice = append(slice, fmt.Sprintf("CODE_SIGN_IDENTITY=%s", c.forceCodeSignIdentity))
-	} else if c.disableCodesign {
+	if c.disableCodesign {
 		slice = append(slice, "CODE_SIGN_IDENTITY=")
 		slice = append(slice, "CODE_SIGNING_REQUIRED=NO")
+		slice = append(slice, "PROVISIONING_PROFILE_SPECIFIER=")
+		slice = append(slice, "PROVISIONING_PROFILE=")
+		slice = append(slice, "DEVELOPMENT_TEAM=")
+	} else {
+		if c.forceDevelopmentTeam != "" {
+			slice = append(slice, fmt.Sprintf("DEVELOPMENT_TEAM=%s", c.forceDevelopmentTeam))
+		}
+
+		if c.forceProvisioningProfileSpecifier != "" {
+			slice = append(slice, fmt.Sprintf("PROVISIONING_PROFILE_SPECIFIER=%s", c.forceProvisioningProfileSpecifier))
+		}
+
+		if c.forceProvisioningProfile != "" {
+			slice = append(slice, fmt.Sprintf("PROVISIONING_PROFILE=%s", c.forceProvisioningProfile))
+		}
+
+		if c.forceCodeSignIdentity != "" {
+			slice = append(slice, fmt.Sprintf("CODE_SIGN_IDENTITY=%s", c.forceCodeSignIdentity))
+		}
+	}
+
+	if c.destination != "" {
+		// "-destination" "id=07933176-D03B-48D3-A853-0800707579E6" => (need the plus `"` marks between the `destination` and the `id`)
+		slice = append(slice, "-destination")
+		slice = append(slice, c.destination)
 	}
 
 	slice = append(slice, c.customBuildActions...)

--- a/vendor/github.com/bitrise-tools/xcode-project/xcodebuild/xcodebuild.go
+++ b/vendor/github.com/bitrise-tools/xcode-project/xcodebuild/xcodebuild.go
@@ -17,6 +17,10 @@ func parseShowBuildSettingsOutput(out string) (serialized.Object, error) {
 			continue
 		}
 
+		if strings.HasPrefix(line, "User defaults from command line") {
+			continue
+		}
+
 		if line == "" {
 			continue
 		}
@@ -37,12 +41,10 @@ func parseShowBuildSettingsOutput(out string) (serialized.Object, error) {
 }
 
 // ShowProjectBuildSettings ...
-func ShowProjectBuildSettings(project, target, configuration, sdk string) (serialized.Object, error) {
+func ShowProjectBuildSettings(project, target, configuration string, customOptions ...string) (serialized.Object, error) {
 	args := []string{"-project", project, "-target", target, "-configuration", configuration}
-	if sdk != "" {
-		args = append(args, "-sdk", sdk)
-	}
 	args = append(args, "-showBuildSettings")
+	args = append(args, customOptions...)
 
 	cmd := command.New("xcodebuild", args...)
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
@@ -54,12 +56,10 @@ func ShowProjectBuildSettings(project, target, configuration, sdk string) (seria
 }
 
 // ShowWorkspaceBuildSettings ...
-func ShowWorkspaceBuildSettings(workspace, scheme, configuration, sdk string) (serialized.Object, error) {
+func ShowWorkspaceBuildSettings(workspace, scheme, configuration string, customOptions ...string) (serialized.Object, error) {
 	args := []string{"-workspace", workspace, "-scheme", scheme, "-configuration", configuration}
-	if sdk != "" {
-		args = append(args, "-sdk", sdk)
-	}
 	args = append(args, "-showBuildSettings")
+	args = append(args, customOptions...)
 
 	cmd := command.New("xcodebuild", args...)
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()

--- a/vendor/github.com/bitrise-tools/xcode-project/xcodeproj/target.go
+++ b/vendor/github.com/bitrise-tools/xcode-project/xcodeproj/target.go
@@ -2,6 +2,7 @@ package xcodeproj
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/bitrise-tools/xcode-project/serialized"
 )
@@ -38,6 +39,39 @@ func (t Target) DependentTargets() []Target {
 	}
 
 	return targets
+}
+
+// DependentExecutableProductTargets ...
+func (t Target) DependentExecutableProductTargets() []Target {
+	var targets []Target
+	for _, targetDependency := range t.Dependencies {
+		childTarget := targetDependency.Target
+		if !childTarget.IsExecutableProduct() {
+			continue
+		}
+
+		targets = append(targets, childTarget)
+
+		childDependentTargets := childTarget.DependentTargets()
+		targets = append(targets, childDependentTargets...)
+	}
+
+	return targets
+}
+
+// IsAppProduct ...
+func (t Target) IsAppProduct() bool {
+	return filepath.Ext(t.ProductReference.Path) == ".app"
+}
+
+// IsAppExtensionProduct ...
+func (t Target) IsAppExtensionProduct() bool {
+	return filepath.Ext(t.ProductReference.Path) == ".appex"
+}
+
+// IsExecutableProduct ...
+func (t Target) IsExecutableProduct() bool {
+	return t.IsAppProduct() || t.IsAppExtensionProduct()
 }
 
 func parseTarget(id string, objects serialized.Object) (Target, error) {
@@ -87,7 +121,13 @@ func parseTarget(id string, objects serialized.Object) (Target, error) {
 	for _, dependencyID := range dependencyIDs {
 		dependency, err := parseTargetDependency(dependencyID, objects)
 		if err != nil {
-			return Target{}, err
+			// KeyNotFoundError can be only raised if the 'target' property not found on the raw target dependency object
+			// we only care about target dependency, which points to a target
+			if serialized.IsKeyNotFoundError(err) {
+				continue
+			} else {
+				return Target{}, err
+			}
 		}
 
 		dependencies = append(dependencies, dependency)

--- a/vendor/github.com/bitrise-tools/xcode-project/xcscheme/xcscheme.go
+++ b/vendor/github.com/bitrise-tools/xcode-project/xcscheme/xcscheme.go
@@ -18,6 +18,11 @@ type BuildableReference struct {
 	ReferencedContainer string `xml:"ReferencedContainer,attr"`
 }
 
+// IsAppReference ...
+func (r BuildableReference) IsAppReference() bool {
+	return filepath.Ext(r.BuildableName) == ".app"
+}
+
 // ReferencedContainerAbsPath ...
 func (r BuildableReference) ReferencedContainerAbsPath(schemeContainerDir string) (string, error) {
 	s := strings.Split(r.ReferencedContainer, ":")
@@ -72,4 +77,21 @@ func Open(pth string) (Scheme, error) {
 	scheme.Path = pth
 
 	return scheme, nil
+}
+
+// AppBuildActionEntry ...
+func (s Scheme) AppBuildActionEntry() (BuildActionEntry, bool) {
+	var entry BuildActionEntry
+	for _, e := range s.BuildAction.BuildActionEntries {
+		if e.BuildForArchiving != "YES" {
+			continue
+		}
+		if !e.BuildableReference.IsAppReference() {
+			continue
+		}
+		entry = e
+		break
+	}
+
+	return entry, (entry.BuildableReference.BlueprintIdentifier != "")
 }

--- a/vendor/github.com/bitrise-tools/xcode-project/xcworkspace/xcworkspace.go
+++ b/vendor/github.com/bitrise-tools/xcode-project/xcworkspace/xcworkspace.go
@@ -2,10 +2,12 @@ package xcworkspace
 
 import (
 	"encoding/xml"
+	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-tools/xcode-project/serialized"
 	"github.com/bitrise-tools/xcode-project/xcodebuild"
 	"github.com/bitrise-tools/xcode-project/xcodeproj"
@@ -39,9 +41,9 @@ func (w Workspace) Scheme(name string) (xcscheme.Scheme, string, bool) {
 	return xcscheme.Scheme{}, "", false
 }
 
-// WrokspaceBuildSettings ...
-func (w Workspace) WrokspaceBuildSettings(scheme, configuration, sdk string) (serialized.Object, error) {
-	return xcodebuild.ShowWorkspaceBuildSettings(w.Path, scheme, configuration, sdk)
+// SchemeBuildSettings ...
+func (w Workspace) SchemeBuildSettings(scheme, configuration string, customOptions ...string) (serialized.Object, error) {
+	return xcodebuild.ShowWorkspaceBuildSettings(w.Path, scheme, configuration, customOptions...)
 }
 
 // Schemes ...
@@ -73,6 +75,13 @@ func (w Workspace) Schemes() (map[string][]xcscheme.Scheme, error) {
 	}
 
 	for _, projectLocation := range projectLocations {
+		if exist, err := pathutil.IsPathExists(projectLocation); err != nil {
+			return nil, fmt.Errorf("failed to check if project exist at: %s, error: %s", projectLocation, err)
+		} else if !exist {
+			// at this point we are interested the schemes visible for the workspace
+			continue
+		}
+
 		project, err := xcodeproj.Open(projectLocation)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description

- Set xcodebuild destination and disabe codesigning in a different methods (instead of setting them via XcodebuildOptions) => It will fix the issue: When the user specified a XcodebuildOptions it override the default one.
- test_multi_target_workspace_custom_derived_data_path test added to check the XCODEBUILD_OPTIONS input.
- refactor(dependency): go-xode and xcode-project dependency update
# Click Up ticket / Github Issue / Discuss Thread

Click Up: https://app.clickup.com/757956/762238/t/40mvg

## Type of change
Please select options that are relevant.
- [X] Issue
- [ ] Enhancement
- [ ] Maintenance
- [ ] Feture request