### PR TITLE
Wrong BuildActionEntry fix for React Native projects

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -124,11 +124,11 @@ workflows:
 
   test_react_native:
     envs:
-    - XCODEBUILD_OPTIONS:
-    - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
-    - BRANCH: watch
-    - BITRISE_PROJECT_PATH: /Users/akosbirmacher/Develop/React/github/BirmacherAkos/SampleProjectReactNative/ios/SampleProjectReactNative.xcodeproj #sample-apps-ios-workspace-swift.xcworkspace
-    - BITRISE_SCHEME: SampleProjectReactNative # sample-apps-ios-workspace-swift
+    - XCODEBUILD_OPTIONS: -UseModernBuildSystem=NO
+    - SAMPLE_APP_URL: https://github.com/BirmacherAkos/sample-project-react-native.git
+    - BRANCH: master
+    - BITRISE_PROJECT_PATH: ios/SampleProjectReactNative.xcodeproj
+    - BITRISE_SCHEME: SampleProjectReactNative
     - SIMULATOR_OS_VERSION: "12.1"
     - OUTPUT_TOOL: xcpretty
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
@@ -140,11 +140,11 @@ workflows:
 
   test_react_native_workspace:
     envs:
-    - XCODEBUILD_OPTIONS:
-    - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
-    - BRANCH: watch
-    - BITRISE_PROJECT_PATH: /Users/akosbirmacher/Develop/React/github/BirmacherAkos/SampleProjectReactNative_workspace/ios/SampleProjectReactNative.xcworkspace #sample-apps-ios-workspace-swift.xcworkspace
-    - BITRISE_SCHEME: SampleProjectReactNative # sample-apps-ios-workspace-swift
+    - XCODEBUILD_OPTIONS: -UseModernBuildSystem=NO
+    - SAMPLE_APP_URL: https://github.com/BirmacherAkos/sample-project-react-native-xcworkspace.git
+    - BRANCH: master
+    - BITRISE_PROJECT_PATH: ios/SampleProjectReactNative.xcworkspace
+    - BITRISE_SCHEME: SampleProjectReactNative
     - SIMULATOR_OS_VERSION: "12.1"
     - OUTPUT_TOOL: xcpretty
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
@@ -186,7 +186,37 @@ workflows:
             git fetch || exit 1
             [[ -n "${COMMIT}" ]] && git checkout "${COMMIT}" || git checkout "${BRANCH}"
             
-    - certificate-and-profile-installer:
+    - script:
+        title: Install yarn deps if needed
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+
+            if [ -f yarn.lock ]; then
+              echo "yarn.lock file found in the root dir. Runing yarn install."
+              yarn install
+            else 
+              echo "No yarn.lock file found in the root dir."
+            fi
+    - script:
+        title: Install cocoapods if needed
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+
+            if [ -f Podfile.lock ]; then
+              echo "Podfile.lock file found in the root dir. Runing pod install."
+              pod install
+            elif [ -f ios/Podfile.lock ]; then
+              echo "Podfile.lock file found in the /ios dir. Runing pod install."
+              cd ios
+              pod install
+              cd ..
+            else
+              echo "No Podfile.lock file found."
+            fi
     - path::./:
         inputs:
         - simulator_os_version: $SIMULATOR_OS_VERSION

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -95,7 +95,7 @@ workflows:
     - BRANCH: watch
     - BITRISE_PROJECT_PATH: sample-apps-ios-workspace-swift.xcworkspace
     - BITRISE_SCHEME: sample-apps-ios-workspace-swift
-    - SIMULATOR_OS_VERSION: "11.4"
+    - SIMULATOR_OS_VERSION: "12.1"
     - OUTPUT_TOOL: xcodebuild
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
     - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app"
@@ -113,11 +113,29 @@ workflows:
     - BRANCH: watch
     - BITRISE_PROJECT_PATH: sample-apps-ios-workspace-swift.xcworkspace
     - BITRISE_SCHEME: sample-apps-ios-workspace-swift
-    - SIMULATOR_OS_VERSION: "11.4"
+    - SIMULATOR_OS_VERSION: "12.1"
     - OUTPUT_TOOL: xcpretty
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
     - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app"
     - BITRISE_APP_DIR_PATH_LIST_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app|$BITRISE_DEPLOY_DIR/bitfall.sample-apps-ios-workspace-swift-watch.app"
+    after_run:
+    - _common
+    - test_react_native
+
+  test_react_native:
+    before_run:
+    - test_workspace
+    envs:
+    - XCODEBUILD_OPTIONS:
+    - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
+    - BRANCH: watch
+    - BITRISE_PROJECT_PATH: /Users/akosbirmacher/Develop/React/github/BirmacherAkos/SampleProjectReactNative/ios/SampleProjectReactNative.xcodeproj #sample-apps-ios-workspace-swift.xcworkspace
+    - BITRISE_SCHEME: SampleProjectReactNative # sample-apps-ios-workspace-swift
+    - SIMULATOR_OS_VERSION: "12.1"
+    - OUTPUT_TOOL: xcpretty
+    - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
+    - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/SampleProjectReactNative.app"
+    - BITRISE_APP_DIR_PATH_LIST_EXPECTED: "$BITRISE_DEPLOY_DIR/SampleProjectReactNative.app"
     after_run:
     - _common
 
@@ -162,7 +180,7 @@ workflows:
           opts:
             is_expand: "true"
         - xcodebuild_options: $XCODEBUILD_OPTIONS
-        - verbose_log: "no"
+        - verbose_log: "yes"
     - script:
         title: Output check
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -132,7 +132,7 @@ workflows:
   test_react_native:
     envs:
     - XCODEBUILD_OPTIONS: -UseModernBuildSystem=NO
-    - SAMPLE_APP_URL: https://github.com/BirmacherAkos/sample-project-react-native.git
+    - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-project-react-native.git
     - BRANCH: master
     - BITRISE_PROJECT_PATH: ios/SampleProjectReactNative.xcodeproj
     - BITRISE_SCHEME: SampleProjectReactNative
@@ -147,7 +147,7 @@ workflows:
   test_react_native_workspace:
     envs:
     - XCODEBUILD_OPTIONS: -UseModernBuildSystem=NO
-    - SAMPLE_APP_URL: https://github.com/BirmacherAkos/sample-project-react-native-xcworkspace.git
+    - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-project-react-native-xcworkspace.git
     - BRANCH: master
     - BITRISE_PROJECT_PATH: ios/SampleProjectReactNative.xcworkspace
     - BITRISE_SCHEME: SampleProjectReactNative

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -35,8 +35,6 @@ workflows:
         - path: "$ORIG_BITRISE_SOURCE_DIR"
         - is_create_path: true
     - go-list:
-    - golint:
-    - errcheck:
     - go-test:
     envs:
     - XCODEBUILD_OPTIONS:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,16 +1,33 @@
-format_version: 5
+format_version: 6
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
-  - BITRISE_STEP_ID: xcode-build-for-simulator
-  - BITRISE_STEP_VERSION: 0.9.0
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/bitrise-steplib/steps-xcode-build-for-simulator.git
   - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
 
   - ORIG_BITRISE_SOURCE_DIR: $BITRISE_SOURCE_DIR
 
 workflows:
+  ci:
+    before_run:
+    - audit-this-step
+    steps:
+    - go-list:
+    - golint:
+    - errcheck:
+    - go-test:
+    after_run:
+    - test_objc
+    - test_multi_target
+    - test_workspace
+    - test_multi_target_workspace_custom_derived_data_path
+    - test_multi_target_workspace
+    - test_react_native
+    - test_react_native_workspace
+
+    
+
   test_objc:
     envs:
     - XCODEBUILD_OPTIONS:
@@ -53,8 +70,6 @@ workflows:
     - _common
 
   test_multi_target:
-    before_run:
-    # - test_xcode_8
     envs:
     - XCODEBUILD_OPTIONS:
     - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-multi-target.git
@@ -70,8 +85,6 @@ workflows:
     - _common
 
   test_workspace:
-    before_run:
-    - test_multi_target
     envs:
     - XCODEBUILD_OPTIONS:
     - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
@@ -93,32 +106,28 @@ workflows:
     - BRANCH: watch
     - BITRISE_PROJECT_PATH: sample-apps-ios-workspace-swift.xcworkspace
     - BITRISE_SCHEME: sample-apps-ios-workspace-swift
-    - SIMULATOR_OS_VERSION: "12.1"
+    - SIMULATOR_OS_VERSION: "11.4"
     - OUTPUT_TOOL: xcodebuild
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
     - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app"
     - BITRISE_APP_DIR_PATH_LIST_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app|$BITRISE_DEPLOY_DIR/bitfall.sample-apps-ios-workspace-swift-watch.app"
     after_run:
     - _common
-    - test_multi_target_workspace
 
   test_multi_target_workspace:
-    before_run:
-    - test_workspace
     envs:
     - XCODEBUILD_OPTIONS:
     - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
     - BRANCH: watch
     - BITRISE_PROJECT_PATH: sample-apps-ios-workspace-swift.xcworkspace
     - BITRISE_SCHEME: sample-apps-ios-workspace-swift
-    - SIMULATOR_OS_VERSION: "12.1"
+    - SIMULATOR_OS_VERSION: "11.4"
     - OUTPUT_TOOL: xcpretty
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
     - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app"
     - BITRISE_APP_DIR_PATH_LIST_EXPECTED: "$BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app|$BITRISE_DEPLOY_DIR/bitfall.sample-apps-ios-workspace-swift-watch.app"
     after_run:
     - _common
-    - test_react_native
 
   test_react_native:
     envs:
@@ -127,14 +136,13 @@ workflows:
     - BRANCH: master
     - BITRISE_PROJECT_PATH: ios/SampleProjectReactNative.xcodeproj
     - BITRISE_SCHEME: SampleProjectReactNative
-    - SIMULATOR_OS_VERSION: "12.1"
+    - SIMULATOR_OS_VERSION: "11.4"
     - OUTPUT_TOOL: xcpretty
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
     - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/SampleProjectReactNative.app"
     - BITRISE_APP_DIR_PATH_LIST_EXPECTED: "$BITRISE_DEPLOY_DIR/SampleProjectReactNative.app"
     after_run:
     - _common
-    - test_react_native_workspace
 
   test_react_native_workspace:
     envs:
@@ -143,7 +151,7 @@ workflows:
     - BRANCH: master
     - BITRISE_PROJECT_PATH: ios/SampleProjectReactNative.xcworkspace
     - BITRISE_SCHEME: SampleProjectReactNative
-    - SIMULATOR_OS_VERSION: "12.1"
+    - SIMULATOR_OS_VERSION: "11.4"
     - OUTPUT_TOOL: xcpretty
     - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
     - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/SampleProjectReactNative.app"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -123,13 +123,27 @@ workflows:
     - test_react_native
 
   test_react_native:
-    before_run:
-    - test_workspace
     envs:
     - XCODEBUILD_OPTIONS:
     - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
     - BRANCH: watch
     - BITRISE_PROJECT_PATH: /Users/akosbirmacher/Develop/React/github/BirmacherAkos/SampleProjectReactNative/ios/SampleProjectReactNative.xcodeproj #sample-apps-ios-workspace-swift.xcworkspace
+    - BITRISE_SCHEME: SampleProjectReactNative # sample-apps-ios-workspace-swift
+    - SIMULATOR_OS_VERSION: "12.1"
+    - OUTPUT_TOOL: xcpretty
+    - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
+    - BITRISE_APP_DIR_PATH_EXPECTED: "$BITRISE_DEPLOY_DIR/SampleProjectReactNative.app"
+    - BITRISE_APP_DIR_PATH_LIST_EXPECTED: "$BITRISE_DEPLOY_DIR/SampleProjectReactNative.app"
+    after_run:
+    - _common
+    - test_react_native_workspace
+
+  test_react_native_workspace:
+    envs:
+    - XCODEBUILD_OPTIONS:
+    - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
+    - BRANCH: watch
+    - BITRISE_PROJECT_PATH: /Users/akosbirmacher/Develop/React/github/BirmacherAkos/SampleProjectReactNative_workspace/ios/SampleProjectReactNative.xcworkspace #sample-apps-ios-workspace-swift.xcworkspace
     - BITRISE_SCHEME: SampleProjectReactNative # sample-apps-ios-workspace-swift
     - SIMULATOR_OS_VERSION: "12.1"
     - OUTPUT_TOOL: xcpretty

--- a/main.go
+++ b/main.go
@@ -246,12 +246,7 @@ func main() {
 		fmt.Println()
 		log.Infof("Copy artifacts from Derived Data to %s", absOutputDir)
 
-		var proj xcodeproj.XcodeProj
-		if xcodeproj.IsXcodeProj(cfg.ProjectPath) {
-			proj, err = xcodeproj.Open(cfg.ProjectPath)
-		} else {
-			proj, _, err = findBuiltProject(cfg.ProjectPath, cfg.Scheme, cfg.Configuration)
-		}
+		proj, _, err := findBuiltProject(cfg.ProjectPath, cfg.Scheme, cfg.Configuration)
 
 		if err != nil {
 			failf("Failed to open xcproj - (%s), error:", cfg.ProjectPath, err)
@@ -363,7 +358,7 @@ func findBuiltProject(pth, schemeName, configurationName string) (xcodeproj.Xcod
 
 	var archiveEntry xcscheme.BuildActionEntry
 	for _, entry := range scheme.BuildAction.BuildActionEntries {
-		if entry.BuildForArchiving != "YES" {
+		if entry.BuildForArchiving != "YES" || !entry.BuildableReference.IsAppReference() {
 			continue
 		}
 		archiveEntry = entry

--- a/main.go
+++ b/main.go
@@ -246,7 +246,13 @@ func main() {
 		fmt.Println()
 		log.Infof("Copy artifacts from Derived Data to %s", absOutputDir)
 
-		proj, _, err := findBuiltProject(cfg.ProjectPath, cfg.Scheme, cfg.Configuration)
+		var proj xcodeproj.XcodeProj
+		if xcodeproj.IsXcodeProj(cfg.ProjectPath) {
+			proj, err = xcodeproj.Open(cfg.ProjectPath)
+		} else {
+			proj, _, err = findBuiltProject(cfg.ProjectPath, cfg.Scheme, cfg.Configuration)
+		}
+
 		if err != nil {
 			failf("Failed to open xcproj - (%s), error:", cfg.ProjectPath, err)
 		}

--- a/main.go
+++ b/main.go
@@ -520,7 +520,13 @@ func mainTargetOfScheme(proj xcodeproj.XcodeProj, scheme string) (xcodeproj.Targ
 		return xcodeproj.Target{}, fmt.Errorf("Failed to found scheme (%s) in project", scheme)
 	}
 
-	blueIdent := sch.BuildAction.BuildActionEntries[0].BuildableReference.BlueprintIdentifier
+	var blueIdent string
+	for _, entry := range sch.BuildAction.BuildActionEntries {
+		if entry.BuildableReference.IsAppReference() {
+			blueIdent = entry.BuildableReference.BlueprintIdentifier
+			break
+		}
+	}
 
 	// Search for the main target
 	for _, t := range projTargets {

--- a/main.go
+++ b/main.go
@@ -247,7 +247,6 @@ func main() {
 		log.Infof("Copy artifacts from Derived Data to %s", absOutputDir)
 
 		proj, _, err := findBuiltProject(cfg.ProjectPath, cfg.Scheme, cfg.Configuration)
-
 		if err != nil {
 			failf("Failed to open xcproj - (%s), error:", cfg.ProjectPath, err)
 		}

--- a/main.go
+++ b/main.go
@@ -483,7 +483,7 @@ func exportArtifacts(proj xcodeproj.XcodeProj, scheme string, schemeBuildDir str
 				return nil, fmt.Errorf("failed to get build target dir for target (%s), error: %s", target.Name, err)
 			}
 
-			log.Debugf("Target (%s) TARGET_BUILD_DIR: %s", buildDir)
+			log.Debugf("Target (%s) TARGET_BUILD_DIR: %s", target.Name, buildDir)
 
 			splitTargetDir = strings.Split(buildDir, "Build/")
 			if len(splitTargetDir) != 2 {


### PR DESCRIPTION
Fix the bug which caused failing build artifact export for React Native projects

- fix: find the app main target
- fix: react native fix;
- test: add react native test cases
- clean: test workflow clean in bitrise.yml