### PR TITLE
Unused parameter customOptions in steps-xcode-build-for-simulator

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bitrise-io/go-utils/errorutil"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/go-utils/sliceutil"
 	"github.com/bitrise-io/go-utils/stringutil"
 	"github.com/bitrise-io/go-xcode/simulator"
 	"github.com/bitrise-io/go-xcode/utility"
@@ -555,10 +556,16 @@ func exportArtifacts(proj xcodeproj.XcodeProj, scheme string, schemeBuildDir str
 
 		//
 		// Find the TARGET_BUILD_DIR for the target
+		options := []string{"-sdk", simulatorName}
 		var targetDir string
 		{
-			customOptions = append(customOptions, []string{"-sdk", simulatorName}...)
-			buildSettings, err := proj.TargetBuildSettings(target.Name, configuration, customOptions...)
+			if sliceutil.IsStringInSlice("-sdk", customOptions) {
+				options = customOptions
+			} else {
+				options = append(options, customOptions...)
+			}
+
+			buildSettings, err := proj.TargetBuildSettings(target.Name, configuration, options...)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get project build settings, error: %s", err)
 			}

--- a/main.go
+++ b/main.go
@@ -557,7 +557,7 @@ func exportArtifacts(proj xcodeproj.XcodeProj, scheme string, schemeBuildDir str
 		// Find the TARGET_BUILD_DIR for the target
 		var targetDir string
 		{
-			customOptions = []string{"-sdk", simulatorName}
+			customOptions = append(customOptions, []string{"-sdk", simulatorName}...)
 			buildSettings, err := proj.TargetBuildSettings(target.Name, configuration, customOptions...)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get project build settings, error: %s", err)
@@ -581,7 +581,6 @@ func exportArtifacts(proj xcodeproj.XcodeProj, scheme string, schemeBuildDir str
 			} else {
 				targetDir = splitTargetDir[1]
 			}
-
 		}
 
 		//


### PR DESCRIPTION
**Description**
The customOptions could change the path of the generated artifacts, so it should be appended to the showBuildSettings call inside exportArtifacts function.

See https://github.com/bitrise-steplib/steps-xcode-build-for-simulator/blob/bd9f118ca4949df48bbf4043950a01d9ee58cdde/main.go#L477 

**Expected result**
–  The value of customOptions input should be appended.

**Acceptance criteria**
add the provided custom options to the showBuildSettings call too