### PR TITLE
Better workspace scheme definition handling

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -50,6 +50,22 @@ workflows:
     after_run:
     - _common
 
+  test_scheme_in_workspace:
+    envs:
+    - XCODEBUILD_OPTIONS:
+    - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
+    - BRANCH: scheme-in-workspace
+    - BITRISE_PROJECT_PATH: sample-apps-ios-workspace-swift.xcworkspace
+    - BITRISE_SCHEME: sample-apps-ios-workspace-swift-workspace
+    - SIMULATOR_OS_VERSION: latest
+    - OUTPUT_TOOL: xcpretty
+    - OUTPUT_DIR: $BITRISE_DEPLOY_DIR
+    - BITRISE_APP_DIR_PATH_EXPECTED: $BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app
+    - BITRISE_APP_DIR_PATH_LIST_EXPECTED: $BITRISE_DEPLOY_DIR/sample-apps-ios-workspace-swift.app
+    - CODE_SIGNING_ALLOWED: "no"
+    after_run:
+    - _common
+
   test_multi_target_workspace_custom_derived_data_path:
     envs:
     - XCODEBUILD_OPTIONS: -derivedDataPath ./ddata


### PR DESCRIPTION
### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The scheme can be either defined on the workspace or the project level. The step correctly reads the scheme at the beginning of its run phase but does not during the execution. It is because we loose the during the information if the project was part of a workspace or not once the main logic is executed. 

The step already passes the scheme name from function to function and reads the scheme over and over again. The scheme settings are not being changed during the runtime so it is fine to read the scheme once at beginning and pass ot down instead of just the scheme name. 

This is what this PR introduces. It eliminates the unnecessary scheme creations and only uses the scheme which was created at the beginning of the execution.

### Changes

- Read the scheme once at the beginning and pass the created struct instead of just the scheme name
- Remove the user of the project struct for the main target determination logic