### PR TITLE
Fix reverting to xcodebuild on xcpretty error

### DIFF
--- a/step.go
+++ b/step.go
@@ -2,6 +2,11 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
 	"github.com/bitrise-io/go-steputils/stepconf"
 	"github.com/bitrise-io/go-steputils/tools"
 	"github.com/bitrise-io/go-utils/errorutil"
@@ -21,10 +26,6 @@ import (
 	"github.com/bitrise-steplib/steps-xcode-archive/utils"
 	"github.com/bitrise-steplib/steps-xcode-build-for-simulator/util"
 	"github.com/kballard/go-shellquote"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
 )
 
 const (
@@ -115,7 +116,9 @@ func (b BuildForSimulatorStep) InstallDependencies(cfg Config) (Config, error) {
 						log.Warnf("%s failed: %s", err)
 					}
 					log.Warnf("Switching to xcodebuild for output tool")
-					outputTool = "xcodebuild"
+
+					cfg.OutputTool = "xcodebuild"
+					return cfg, nil
 				}
 			}
 		}
@@ -124,10 +127,12 @@ func (b BuildForSimulatorStep) InstallDependencies(cfg Config) (Config, error) {
 	if err != nil {
 		log.Warnf("Failed to determine xcpretty version, error: %s", err)
 		log.Printf("Switching to xcodebuild for output tool")
-		outputTool = "xcodebuild"
-	}
-	log.Printf("- xcprettyVersion: %s", xcprettyVersion.String())
 
+		cfg.OutputTool = "xcodebuild"
+		return cfg, nil
+	}
+
+	log.Printf("- xcprettyVersion: %s", xcprettyVersion.String())
 	cfg.OutputTool = outputTool
 	return cfg, nil
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Fixes a nil pointer dereference:
```
[34;1mChecking if output tool (xcpretty) is installed
[0m[33;1mFailed to check if xcpretty is installed, error: rbenv: version `2.7.2' is not installed (set by /Users/vagrant/git/.ruby-version): error: exit status 1
[0mSwitching to xcodebuild for output tool
[33;1mFailed to determine xcpretty version, error: exit status 1
[0mSwitching to xcodebuild for output tool
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x12623b9]
```

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
