### PR TITLE
Remove `cache_level` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | `xcodebuild_options` | Additional options to be added to the executed xcodebuild command.  Prefer using `Build settings (xcconfig)` input for specifying `-xcconfig` option. You can't use both. |  |  |
 | `log_formatter` | Defines how xcodebuild command's log is formatted.  Available options: - `xcpretty`: The xcodebuild command's output will be prettified by xcpretty. - `xcodebuild`: Only the last 20 lines of raw xcodebuild output will be visible in the build log.  The raw xcodebuild log will be exported in all cases. | required | `xcpretty` |
 | `output_dir` | This directory will contain the generated artifacts. | required | `$BITRISE_DEPLOY_DIR` |
-| `cache_level` | Defines what cache content should be automatically collected.  Available options:  - `none`: Disable collecting cache content - `swift_packages`: Collect Swift PM packages added to the Xcode project | required | `swift_packages` |
 | `verbose_log` | If this input is set, the Step will print additional logs for debugging. | required | `no` |
 </details>
 

--- a/build.go
+++ b/build.go
@@ -5,29 +5,13 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/command"
-	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/xcodebuild"
-	cache "github.com/bitrise-io/go-xcode/xcodecache"
 	"github.com/bitrise-io/go-xcode/xcpretty"
 	"github.com/bitrise-steplib/steps-xcode-build-for-simulator/util"
 )
-
-func runCommandWithRetry(cmd *xcodebuild.CommandBuilder, useXcpretty bool, swiftPackagesPath string) (string, error) {
-	output, err := runCommand(cmd, useXcpretty)
-	if err != nil && swiftPackagesPath != "" && strings.Contains(output, cache.SwiftPackagesStateInvalid) {
-		log.Warnf("Build failed, swift packages cache is in an invalid state, error: %s", err)
-		log.RWarnf("xcode-build-for-simulator", "swift-packages-cache-invalid", nil, "swift packages cache is in an invalid state")
-		if err := os.RemoveAll(swiftPackagesPath); err != nil {
-			return output, fmt.Errorf("failed to remove invalid Swift package caches, error: %s", err)
-		}
-		return runCommand(cmd, useXcpretty)
-	}
-	return output, err
-}
 
 func prepareCommand(xcodeCmd *xcodebuild.CommandBuilder, useXcpretty bool, output *bytes.Buffer) (*command.Model, *xcpretty.CommandModel) {
 	if useXcpretty {

--- a/step.go
+++ b/step.go
@@ -20,7 +20,6 @@ import (
 	"github.com/bitrise-io/go-utils/ziputil"
 	"github.com/bitrise-io/go-xcode/v2/xcconfig"
 	"github.com/bitrise-io/go-xcode/xcodebuild"
-	cache "github.com/bitrise-io/go-xcode/xcodecache"
 	"github.com/bitrise-io/go-xcode/xcpretty"
 	"github.com/kballard/go-shellquote"
 
@@ -48,9 +47,6 @@ type Config struct {
 
 	// Output export
 	OutputDir string `env:"output_dir,required"`
-
-	// Caching
-	CacheLevel string `env:"cache_level,opt[none,swift_packages]"`
 
 	// Debugging
 	VerboseLog bool `env:"verbose_log,required"`
@@ -125,8 +121,6 @@ func (b BuildForSimulatorStep) ProcessConfig() (RunOpts, error) {
 		LogFormatter:                config.LogFormatter,
 
 		OutputDir: config.OutputDir,
-
-		CacheLevel: config.CacheLevel,
 	}, nil
 }
 
@@ -253,12 +247,7 @@ func (s BuildForSimulatorStep) Run(cfg RunOpts) (ExportOptions, error) {
 			archiveCmd.SetXCConfigPath(xcconfigPath)
 		}
 
-		swiftPackagesPath, err := cache.SwiftPackagesPath(absProjectPath)
-		if err != nil {
-			return ExportOptions{}, fmt.Errorf("failed to get Swift Packages path: %s", err)
-		}
-
-		rawXcodeBuildOut, err := runCommandWithRetry(archiveCmd, cfg.LogFormatter == "xcpretty", swiftPackagesPath)
+		rawXcodeBuildOut, err := runCommand(archiveCmd, cfg.LogFormatter == "xcpretty")
 		if err != nil {
 			if cfg.LogFormatter == "xcpretty" {
 				log.Errorf("\nLast lines of the Xcode's build log:")

--- a/step.yml
+++ b/step.yml
@@ -179,25 +179,6 @@ inputs:
     description: This directory will contain the generated artifacts.
     is_required: true
 
-# Caching
-
-- cache_level: swift_packages
-  opts:
-    category: Caching
-    title: Enable collecting cache content
-    summary: Defines what cache content should be automatically collected.
-    description: |-
-      Defines what cache content should be automatically collected.
-
-      Available options:
-
-      - `none`: Disable collecting cache content
-      - `swift_packages`: Collect Swift PM packages added to the Xcode project
-    is_required: true
-    value_options:
-    - none
-    - swift_packages
-
 # Debugging
 
 - verbose_log: "no"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR* [version update](https://semver.org/)

### Context

This has been deprecated for a while (old Cache pull/push steps), and the same can be achieved with the new SPM caching steps better. Also, this input wasn't wired into anything real after #46.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
